### PR TITLE
Do not ask for exit confirmation

### DIFF
--- a/src/replhelper.py
+++ b/src/replhelper.py
@@ -41,11 +41,12 @@ def ipython_options(**kwargs):
 
     c = Config()
     c.TerminalIPythonApp.display_banner = False
+    c.TerminalInteractiveShell.confirm_exit = False
 
     return dict(user_ns=user_ns, config=c)
 
 
 def customized_ipython(**kwargs):
     import IPython
-    print()
+    print('')
     IPython.start_ipython(**ipython_options(**kwargs))


### PR DESCRIPTION
Hi!

This solves https://github.com/tkf/IPython.jl/issues/1 and https://github.com/tkf/IPython.jl/issues/2. It also solves a cosmetic problem in Python 2.

Before this change (problems: this package prints `()` and the console gets stuck with exit confirmation):
![imagen](https://user-images.githubusercontent.com/2822757/39893342-b8d86c70-54a3-11e8-8d1b-30fe28d210f8.png)

After this change:
![imagen](https://user-images.githubusercontent.com/2822757/39893440-008f6186-54a4-11e8-87df-08014359ebfd.png)

Best regards,