### PR TITLE
Install IPython and pyjulia in deps/build.jl

### DIFF
--- a/ci/before_script.jl
+++ b/ci/before_script.jl
@@ -9,8 +9,6 @@ info("Pkg.build(IPython)")
 Pkg.build("IPython")
 
 using IPython
-IPython.install_dependency("ipython"; force=true)
-IPython.install_dependency("julia"; force=true)
 IPython.install_dependency("pytest"; force=true)
 
 info("show_versions.jl")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,8 @@
+using PyCall
+using Conda
+using IPython
+
+if PyCall.conda
+    Conda.add("ipython")
+    IPython.install_dependency("julia"; force=true)
+end


### PR DESCRIPTION
I'm not sure if it is the right thing to do.  Installing IPython via Conda.jl is fine but pyjulia has to be installed via pip which may break the conda environment that is used by Conda.jl.

See #4