### PR TITLE
Support ptipython

### DIFF
--- a/src/replhelper.py
+++ b/src/replhelper.py
@@ -130,3 +130,12 @@ def customized_ipython(**kwargs):
     import IPython
     print()
     IPython.start_ipython(**ipython_options(**kwargs))
+
+
+@print_instruction_on_import_error
+def customized_ptipython(**kwargs):
+    from ptpython.ipython import embed
+    print()
+    embed(**ipython_options(**kwargs))
+# https://github.com/jonathanslenders/ptpython/blob/master/ptpython/entry_points/run_ptipython.py
+# https://github.com/jonathanslenders/ptpython/blob/master/ptpython/ipython.py


### PR DESCRIPTION
I thought ptypthon may fix segmentation fault issue since it uses prompt_toolkit (https://github.com/tkf/IPython.jl/issues/7#issuecomment-389034802).

It didn't work, though:

```
julia> using IPython; IPython._start_ipython(:customized_ptipython)   
                                                                      
Python 3.5.2 |Continuum Analytics, Inc.| (default, Jul  2 2016, 17:53:06) 
Type 'copyright', 'credits' or 'license' for more information
IPython 6.4.0 -- An enhanced Interactive Python. Type '?' for help.
                                                             
In [1]: sin = Main.sin

In [2]: s

signal (11): Segmentation fault
while loading no file, in expression starting on line 0
zsh: segmentation fault (core dumped)  julia
```

Still, it makes sense to support Python REPLs other than IPython?